### PR TITLE
Corrected NER label look up

### DIFF
--- a/feature_extraction.py
+++ b/feature_extraction.py
@@ -380,7 +380,7 @@ class STWRFeatureExtractor(object):
 
         # --- Possible speaker features ---
         # Is subject a pronoun, a person NE or a "Person" head noun -> possible speaker
-        cand_speakers = [tokens[i] for i,tag in enumerate(tags) if (tag in['PPER', 'PIS', 'PDS'] or (tag in ['NE', 'NNE'] and 'PER' in [ent for ent in doc.ents if tokens[i].idx >= ent.start and tokens[i].idx <= ent.end]))]
+        cand_speakers = [tokens[i] for i,tag in enumerate(tags) if (tag in['PPER', 'PIS', 'PDS'] or (tag in ['NE', 'NNE'] and 'PER' in [ent.label_ for ent in doc.ents if tokens[i].idx >= ent.start and tokens[i].idx <= ent.end]))]
 
         # Check whether any noun phrase has a head that is a synset of "Person" in Germanet
         person = []


### PR DESCRIPTION
This change fixes the look up of the NER-label "PER" in the spacy entities. This used to crash with a spacy exception.

To reproduce the issue, run the following:
```python
import spacy
NLP = spacy.load('de_core_news_sm')
doc = NLP("Kopfschüttelnd grinsend stand die Alte im Kreise dieser guten Bekanntschaft ,")
"PER" in doc.ents
```
`TypeError: Argument 'other' has incorrect type (expected spacy.tokens.span.Span, got str)`